### PR TITLE
Add new operator for R_RISCV_GOT_HI20

### DIFF
--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -163,15 +163,19 @@ Directive    | Arguments                      | Description
 
 The following table lists assembler relocation expansions:
 
-Assembler Notation       | Description                 | Instruction / Macro
-:----------------------  | :---------------            | :-------------------
-%hi(symbol)              | Absolute (HI20)             | lui
-%lo(symbol)              | Absolute (LO12)             | load, store, add
-%pcrel_hi(symbol)        | PC-relative (HI20)          | auipc
-%pcrel_lo(label)         | PC-relative (LO12)          | load, store, add
-%tprel_hi(symbol)        | TLS LE "Local Exec"         | auipc
-%tprel_lo(label)         | TLS LE "Local Exec"         | load, store, add
-%tprel_add(offset)       | TLS LE "Local Exec"         | add
+Assembler Notation          | Description                    | Instruction / Macro
+:----------------------     | :---------------               | :-------------------
+%hi(symbol)                 | Absolute (HI20)                | lui
+%lo(symbol)                 | Absolute (LO12)                | load, store, add
+%pcrel_hi(symbol)           | PC-relative (HI20)             | auipc
+%pcrel_lo(label)            | PC-relative (LO12)             | load, store, add
+%tprel_hi(symbol)           | TLS LE "Local Exec"            | auipc
+%tprel_lo(label)            | TLS LE "Local Exec"            | load, store, add
+%tprel_add(offset)          | TLS LE "Local Exec"            | add
+%tls_ie_pcrel_hi(symbol) \* | TLS IE "Initial Exec" (HI20)   | auipc
+%tls_gd_pcrel_hi(symbol) \* | TLS GD "Global Dynamic" (HI20) | auipc
+
+\* These reuse %pcrel_lo(label) for their lower half
 
 Labels
 ------------

--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -257,6 +257,36 @@ as seen by objdump:
 			4: R_RISCV_PCREL_LO12_I	.L11
 ```
 
+GOT-indirect addressing
+------------------------
+
+The following example shows how to load an address from the GOT:
+
+```
+.section .text
+.globl _start
+_start:
+1:	    auipc a0, %got_pcrel_hi(msg) # load msg(hi)
+	    ld    a0, %pcrel_lo(1b)(a0)  # load msg(lo)
+	    jal ra, puts
+2:	    j 2b
+
+.section .rodata
+msg:
+	    .string "Hello World\n"
+```
+
+which generates the following assembler output and relocations
+as seen by objdump:
+
+```
+0000000000000000 <_start>:
+   0:	00000517          	auipc	a0,0x0
+			0: R_RISCV_GOT_HI20	msg
+   4:	00053503          	ld	a0,0(a0) # 0 <_start>
+			4: R_RISCV_PCREL_LO12_I	.L11
+```
+
 Load Immediate
 -------------------
 
@@ -302,7 +332,7 @@ msg:
 ```
 
 which generates the following assembler output and relocations
-as seen by objdump:
+for non-PIC as seen by objdump:
 
 ```
 0000000000000000 <_start>:
@@ -310,6 +340,17 @@ as seen by objdump:
 			0: R_RISCV_PCREL_HI20	msg
    4:	00850513          	addi	a0,a0,8 # 8 <_start+0x8>
 			4: R_RISCV_PCREL_LO12_I	.L11
+```
+
+and generates the following assembler output and relocations
+for PIC as seen by objdump:
+
+```
+0000000000000000 <_start>:
+   0:	00000517          	auipc	a0,0x0
+			0: R_RISCV_GOT_HI20	msg
+   4:	00053503          	ld	a0,0(a0) # 0 <_start>
+			4: R_RISCV_PCREL_LO12_I	.L0
 ```
 
 Constants

--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -174,6 +174,7 @@ Assembler Notation          | Description                    | Instruction / Mac
 %tprel_add(offset)          | TLS LE "Local Exec"            | add
 %tls_ie_pcrel_hi(symbol) \* | TLS IE "Initial Exec" (HI20)   | auipc
 %tls_gd_pcrel_hi(symbol) \* | TLS GD "Global Dynamic" (HI20) | auipc
+%got_pcrel_hi(symbol) \*    | GOT PC-relative (HI20)         | auipc
 
 \* These reuse %pcrel_lo(label) for their lower half
 


### PR DESCRIPTION
Currently, the `la` pseudo-instruction cannot be expanded for position-independent code by the compiler, and it must emit the pseudo-instruction instead. This pull request introduces a new `%got_pcrel_hi` operator for this purpose.

### Name Bikeshedding

We have `%pcrel_hi` and `%tprel_hi` which would suggest `%got_hi` is a logical option. However, we also have `%tls_ie_pcrel_hi` and `%tls_gd_pcrel_hi` which would lead to `%got_pcrel_hi` being the new name. Despite `%got_hi` being possibly the more obvious choice at first, given that it's shorter, I am instead proposing `%got_pcrel_hi`. This is because `%tprel_hi` has its own `%tprel_lo`, whereas `%tls_ie_pcrel_hi` and `%tls_gd_pcrel_hi` reuse `%pcrel_lo`, much like this new operator, and therefore including `pcrel` in the name is both more consistent and makes it seem less odd that it's used in conjunction with `%pcrel_lo`. Thoughts?