### PR TITLE
Document branch relaxation

### DIFF
--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -449,6 +449,36 @@ as seen by `objdump`:
   14:	00028067          	jr	t0 # 0x10
 ```
 
+Branches
+--------------------
+
+Unconditional branches are implemented by the `j(al)?r?` pseudoinstructions.
+(The underlying instructions are `jalr?`.)
+The `j(al)?` targets can be any symbol or address.
+
+Conditional branches are implemented by the `b(l|g)(t|e)(z|u)?` and `b(eq|ne)z?` pseudoinstructions.
+(The underlying instructions are `b(lt|ge)u?` and `b(eq|ne)`.)
+Again, the targets can be any symbol or address.
+
+Various relaxations are performed when the target's offset from the branch exceeds the range of the underlying instruction's immediate field.  
+
+For example,
+
+```assembly
+        beqz t0, foo
+```
+
+may be relaxed to a sequence of the form
+
+```assembly
+        bnez t0, 1f
+        j    foo 
+1:
+```
+
+The `bnez` is further relaxed to `bne`, while `j` is relaxed to `jal` with a relocation.
+
+
 Floating-point rounding modes
 -----------------------------
 


### PR DESCRIPTION
The GNU toolchain currently implements various branch relaxations, but this behavior is undocumented and I am not familiar with the details. I am submitting this PR in hopes of starting a conversation to clarify these details. **I do not intend for this PR be accepted as-is.**

At present, the boundaries between the ABI, the toolchain behavior/interface, and the assembly language are frustratingly blurry. It is possible that this PR will prompt changes in one or both of the companion manuscripts: 
https://github.com/riscv/riscv-elf-psabi-doc/blob/master/riscv-elf.md
https://github.com/riscv/riscv-toolchain-conventions/blob/master/README.mkd