### PR TITLE
Remove broken link

### DIFF
--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -113,11 +113,8 @@ Latest Specifications draft repository:
 
 ## Instructions
 
-# RISC-V User Level ISA Specification
+# RISC-V ISA Specifications
 https://riscv.org/specifications/
-
-# RISC-V Privileged ISA Specification
-https://riscv.org/specifications/privileged-isa/
 
 ## Instruction Aliases
 


### PR DESCRIPTION
Seems like privileged spec URL is no longer working and is listed in the same page with User Level specification