### PR TITLE
Add pseudoinstruction: sext.b, sext.h, zext.b, zext.h and zext.w

### DIFF
--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -532,8 +532,8 @@ fail_msg:
 
 ## A listing of standard RISC-V pseudoinstructions
 
-Pseudoinstruction            | Base Instruction(s)                                           | Meaning
-:----------------------------|:--------------------------------------------------------------|:-------
+Pseudoinstruction            | Base Instruction(s)                                           | Meaning   | Comment
+:----------------------------|:--------------------------------------------------------------|:----------|:--------|
 la rd, symbol                | auipc rd, symbol[31:12]; addi rd, rd, symbol[11:0]            | Load address
 l{b\|h\|w\|d} rd, symbol     | auipc rd, symbol[31:12]; l{b\|h\|w\|d} rd, symbol[11:0]\(rd\) | Load global
 s{b\|h\|w\|d} rd, symbol, rt | auipc rt, symbol[31:12]; s{b\|h\|w\|d} rd, symbol[11:0]\(rt\) | Store global
@@ -545,7 +545,12 @@ mv rd, rs                    | addi rd, rs, 0                                   
 not rd, rs                   | xori rd, rs, -1                                               | One’s complement
 neg rd, rs                   | sub rd, x0, rs                                                | Two’s complement
 negw rd, rs                  | subw rd, x0, rs                                               | Two’s complement word
+sext.b rd, rs                | slli rd, rs, XLEN - 8; srai rd, rd, XLEN - 8                  | Sign extend byte | It will expand another instruction sequence when B extension is available*[1]
+sext.h rd, rs                | slli rd, rs, XLEN - 16; srai rd, rd, XLEN - 16                | Sign extend half word | It will expand another instruction sequence when B extension is available*[1]
 sext.w rd, rs                | addiw rd, rs, 0                                               | Sign extend word
+zext.b rd, rs                | andi rd, rs, 255                                              | Zero extend byte
+zext.h rd, rs                | slli rd, rs, XLEN - 16; srli rd, rd, XLEN - 16                | Zero extend half word | It will expand another instruction sequence when B extension is available*[1]
+zext.w rd, rs                | slli rd, rs, XLEN - 32; srli rd, rd, XLEN - 32                | Zero extend word | It will expand another instruction sequence when B extension is available*[1]
 seqz rd, rs                  | sltiu rd, rs, 1                                               | Set if = zero
 snez rd, rs                  | sltu rd, x0, rs                                               | Set if != zero
 sltz rd, rs                  | slt rd, rs, x0                                                | Set if < zero
@@ -574,6 +579,8 @@ ret                          | jalr x0, x1, 0                                   
 call offset                  | auipc x6, offset[31:12]; jalr x1, x6, offset[11:0]            | Call far-away subroutine
 tail offset                  | auipc x6, offset[31:12]; jalr x0, x6, offset[11:0]            | Tail call far-away subroutine
 fence                        | fence iorw, iorw                                              | Fence on all memory and I/O
+
+* [1] We don't specific code sequence for B-extension, since B-extension still not ratified or frozen, we'll specify the expansion sequence once it's frozen.
 
 ## Pseudoinstructions for accessing control and status registers
 

--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -545,12 +545,12 @@ mv rd, rs                    | addi rd, rs, 0                                   
 not rd, rs                   | xori rd, rs, -1                                               | One’s complement
 neg rd, rs                   | sub rd, x0, rs                                                | Two’s complement
 negw rd, rs                  | subw rd, x0, rs                                               | Two’s complement word
-sext.b rd, rs                | slli rd, rs, XLEN - 8; srai rd, rd, XLEN - 8                  | Sign extend byte | It will expand another instruction sequence when B extension is available*[1]
-sext.h rd, rs                | slli rd, rs, XLEN - 16; srai rd, rd, XLEN - 16                | Sign extend half word | It will expand another instruction sequence when B extension is available*[1]
+sext.b rd, rs                | slli rd, rs, XLEN - 8; srai rd, rd, XLEN - 8                  | Sign extend byte | It will expand to another instruction sequence when B extension is available*[1]
+sext.h rd, rs                | slli rd, rs, XLEN - 16; srai rd, rd, XLEN - 16                | Sign extend half word | It will expand to another instruction sequence when B extension is available*[1]
 sext.w rd, rs                | addiw rd, rs, 0                                               | Sign extend word
 zext.b rd, rs                | andi rd, rs, 255                                              | Zero extend byte
-zext.h rd, rs                | slli rd, rs, XLEN - 16; srli rd, rd, XLEN - 16                | Zero extend half word | It will expand another instruction sequence when B extension is available*[1]
-zext.w rd, rs                | slli rd, rs, XLEN - 32; srli rd, rd, XLEN - 32                | Zero extend word | It will expand another instruction sequence when B extension is available*[1]
+zext.h rd, rs                | slli rd, rs, XLEN - 16; srli rd, rd, XLEN - 16                | Zero extend half word | It will expand to another instruction sequence when B extension is available*[1]
+zext.w rd, rs                | slli rd, rs, XLEN - 32; srli rd, rd, XLEN - 32                | Zero extend word | It will expand to another instruction sequence when B extension is available*[1]
 seqz rd, rs                  | sltiu rd, rs, 1                                               | Set if = zero
 snez rd, rs                  | sltu rd, x0, rs                                               | Set if != zero
 sltz rd, rs                  | slt rd, rs, x0                                                | Set if < zero
@@ -580,7 +580,7 @@ call offset                  | auipc x6, offset[31:12]; jalr x1, x6, offset[11:0
 tail offset                  | auipc x6, offset[31:12]; jalr x0, x6, offset[11:0]            | Tail call far-away subroutine
 fence                        | fence iorw, iorw                                              | Fence on all memory and I/O
 
-* [1] We don't specific code sequence for B-extension, since B-extension still not ratified or frozen, we'll specify the expansion sequence once it's frozen.
+* [1] We don't specify the code sequence when the B-extension is present, since B-extension still not ratified or frozen. We will specify the expansion sequence once it's frozen.
 
 ## Pseudoinstructions for accessing control and status registers
 


### PR DESCRIPTION
Add `sext.b`, `sext.h`, `zext.b`, `zext.h` and `zext.w`, and mention `sext.b` and `sext.h` could be non pseudo instruction, the motivation is we already has `sext.w` now, and B ext also want to define more pseudo for `sext` or `zext`, so why not add to the baseline pseudo instruction, and let assembler pick best way to expand.