### PR TITLE
Document (c)lui immediate

### DIFF
--- a/riscv-asm.md
+++ b/riscv-asm.md
@@ -306,6 +306,12 @@ Which, for RV32I, generates the following assembler output, as seen by `objdump`
    4:	eef50513          	addi	a0,a0,-273 # deadbeef <CONSTANT+0x0>
 ```
 
+Load Upper Immediate's Immediate
+-----------------------------------
+
+The immediate argument to `lui` is an integer in the interval [0x0, 0xfffff]. 
+Its compressed form, `c.lui`, accepts only those in the subintervals [0x1, 0x1f] and [0xfffe0, 0xfffff]. 
+
 Load Address
 -----------------
 


### PR DESCRIPTION
My (mis)reading of the ISA manual leads me to expect `c.lui` to accept a nonzero integer immediate in the interval [-32, 31]. The GNU assembler rejects values in [-32, -1]. This PR aims to clear up this behavior I found counterintuitive. 

EDIT: Writing in a hurry, I originally worded this more strongly than I meant. GAS's behavior is actually rather reasonable.